### PR TITLE
Bugfix/utf8 restriction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "aws-ec2-imdsv2-get"
-version = "1.0.3"
+version = "1.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-ec2-imdsv2-get"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
This should fix the use of tar files and other non text files in user-data script. I was able to test that it remains fully functional for script files. I tried to test with tar files but was having an issue with the EC2 Console (contacting appropriate oncalls) where it was dropping data. But code should be correct. Will update when i finally get a better test done but wanted to PR this up

Issues:
 - #3 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
