### PR TITLE
adding support for IPv6

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,14 +3,24 @@ use std::env;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 
-const IMDS_URL: &str = "169.254.169.254:80";
+const IMDS_URL_V4: &str = "169.254.169.254:80";
+const IMDS_URL_V6: &str = "[fd00:ec2::254]:80";
+
+fn get_imds_url() -> String {
+    if TcpStream::connect(IMDS_URL_V6).is_ok() {
+        IMDS_URL_V6.to_string()
+    } else {
+        IMDS_URL_V4.to_string()
+    }
+}
 
 fn request(
     method: &str,
     path: &str,
     headers: HashMap<String, String>,
 ) -> std::io::Result<(u64, Vec<u8>)> {
-    let mut socket = TcpStream::connect(IMDS_URL)?;
+    let imds_url = get_imds_url();
+    let mut socket = TcpStream::connect(imds_url)?;
 
     let header = format!(
         "{} /{} HTTP/1.1\r\n{}\r\n",


### PR DESCRIPTION
# issues: Add support for retrieval of IMDS from IPv6 Endpoint https://github.com/aws/aws-ec2-imdsv2-get/issues/4

# Description of changes:

Adding support for IPv6. Since IPv6 should be explicitly enabled via [http-protocol-ipv6](https://docs.aws.amazon.com/cli/latest/reference/ec2/modify-instance-metadata-options.html) on Nitro instance I have to insist on the following:

1. the endpoint cannot be enabled on xen instances:
`An error occurred (UnsupportedOperation) when calling the ModifyInstanceMetadataOptions operation: The HttpProtocolIpv6 metadata option cannot be enabled for Xen-backed instance types.`
2. The endpoint is not reachable by default:
`# nc -zv fd00:ec2::254 80
Ncat: Version 7.93 ( https://nmap.org/ncat )
Ncat: Network is unreachable.`

This being said I simply added a logic to check if IPv6 endpoint is reachable (enabled on purpose so either we are in IPv6 only or dualstack) it would be used else IPv4. 

This has been tested in IPv6 and IPv6 setups, testing worklog from dualstack blocked IPv4 via Os firewall:
```# iptables -L
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination         

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         
REJECT     tcp  --  anywhere             169.254.169.254      tcp dpt:http reject-with icmp-port-unreachable

# curl -w '\n' -X PUT "http://[fd00:ec2::254]/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"
AQAEAF2hGbE0706nCnz4Zp2hXcVPAPjrz5PnXBIsOHEGkBH_YHqgdg==                                                          

# curl -w '\n' -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"
curl: (7) Failed to connect to 169.254.169.254 port 80 after 0 ms: Couldn't connect to server

# ./aws-ec2-imdsv2-get latest/meta-data/
ami-id
ami-launch-index
ami-manifest-path
block-device-mapping/
events/
hostname
identity-credentials/
instance-action
instance-id
instance-life-cycle
instance-type
ipv6
local-hostname
mac
metrics/
network/
placement/
profile
public-keys/
reservation-id
security-groups
services/
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
